### PR TITLE
able to get channel overrides* (properly)

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -1140,7 +1140,7 @@ type UserGuildSettingsChannelOverride struct {
 	Muted                bool        `json:"muted"`
 	MuteConfig           *MuteConfig `json:"mute_config"`
 	MessageNotifications int         `json:"message_notifications"`
-	ChannelID            string      `json:"channel_id"`
+	ChannelID            interface{}      `json:"channel_id"`
 }
 
 // A UserGuildSettings stores data for a users guild settings.


### PR DESCRIPTION
I was attempting to add mute guild (/channel) /group chat support for gord but then ran into this issue with the discordgo fork


Edit: to clarify, there is no possible way to get channel overrides currently (due to this issue) 